### PR TITLE
Add 'prunelinks' command to inspect and remove redundant project/NuGe…

### DIFF
--- a/Csproj/Commands/PruneLinks.cs
+++ b/Csproj/Commands/PruneLinks.cs
@@ -1,0 +1,164 @@
+﻿using System.ComponentModel;
+using Spectre.Console.Cli;
+using Spectre.Console;
+using Csproj.DomainServices;
+
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+// ReSharper disable ClassNeverInstantiated.Global
+
+namespace Csproj.Commands;
+
+internal sealed class PruneLinks : Command<PruneLinks.Settings>
+{
+    public class Settings : CommandSettings
+    {
+        [Description("Solution file path (.sln)")]
+        [CommandOption("-s|--solution")]
+        public string SolutionPath { get; set; } = string.Empty;
+
+        [Description("Dryrun mode. Only show what would be changed.")]
+        [CommandOption("-D|--dryrun")]
+        public bool DryRun { get; set; }
+
+        [Description("Create a backup of the project file before editing.")]
+        [CommandOption("-b|--backup")]
+        public bool Backup { get; set; }
+
+        [Description("Show the reference tree for each project.")]
+        [CommandOption("-v|--verbose")]
+        public bool Verbose { get; set; }
+
+        [Description("Output the dependency graph as a Markdown file with Mermaid syntax.")]
+        [CommandOption("--graph-md")]
+        public string GraphMdPath { get; set; } = string.Empty;
+    }
+
+    public override int Execute(CommandContext context, Settings settings)
+    {
+        if (string.IsNullOrWhiteSpace(settings.SolutionPath) || !File.Exists(settings.SolutionPath))
+        {
+            AnsiConsole.MarkupLine($"[red]Solution file not found: {settings.SolutionPath}[/]");
+            return -1;
+        }
+
+        var projects = SolutionFileParser.GetAllProjectPaths(settings.SolutionPath).ToList();
+        var originalGraph = ProjectManipulator.BuildDependencyGraph(projects);
+
+        // Find root project(s) once
+        var allProjects = projects.ToHashSet();
+
+        // Prune redundant links and get updated graph
+        var changes = ProjectManipulator.PruneRedundantLinks(originalGraph, settings.DryRun, settings.Backup);
+        var displayGraph = settings.DryRun ? originalGraph : ProjectManipulator.BuildDependencyGraph(projects); // Rebuild after prune
+
+        if (!settings.DryRun)
+        {
+            // Rebuild graph after pruning
+            displayGraph = ProjectManipulator.BuildDependencyGraph(projects);
+        }
+
+        if (settings.Verbose)
+        {
+            var displayReferencedProjects = new HashSet<string>();
+            foreach (var r in displayGraph.Values.SelectMany(refs => refs).Where(r => r.EndsWith(".csproj")))
+            {
+                displayReferencedProjects.Add(r);
+            }
+            var displayRootProjects = allProjects.Except(displayReferencedProjects).ToList();
+            foreach (var proj in displayRootProjects)
+            {
+                var tree = new Tree($"[bold]{Path.GetFileName(proj)}[/]");
+                PrintReferenceTree(displayGraph, proj, tree, []);
+                AnsiConsole.Write(tree);
+            }
+        }
+
+        // Determine output file path for --graph-md
+        string? outputPath;
+        var solutionDir = Path.GetDirectoryName(settings.SolutionPath);
+        if (!string.IsNullOrWhiteSpace(settings.GraphMdPath))
+        {
+            outputPath = Path.IsPathRooted(settings.GraphMdPath)
+                ? settings.GraphMdPath
+                : Path.Combine(solutionDir ?? string.Empty, settings.GraphMdPath);
+        }
+        else
+        {
+            var solutionName = Path.GetFileNameWithoutExtension(settings.SolutionPath);
+            outputPath = Path.Combine(solutionDir ?? string.Empty, solutionName + ".md");
+        }
+
+        if (!string.IsNullOrWhiteSpace(outputPath))
+        {
+            var outputFileName = Path.GetFileName(outputPath);
+            // Use displayGraph for Markdown
+            var mdReferencedProjects = new HashSet<string>();
+            foreach (var r in displayGraph.Values.SelectMany(refs => refs).Where(r => r.EndsWith(".csproj")))
+            {
+                mdReferencedProjects.Add(r);
+            }
+            var mdRootProjects = allProjects.Except(mdReferencedProjects).ToList();
+            var mdTitle = mdRootProjects.Count > 0 ? Path.GetFileNameWithoutExtension(mdRootProjects[0]) : "dependencies";
+            var mermaidMd = GenerateMermaidMarkdown(displayGraph, mdTitle, outputFileName);
+            File.WriteAllText(outputPath, mermaidMd);
+            AnsiConsole.MarkupLine($"[green]Dependency graph written to:[/] {outputPath}");
+        }
+
+        if (changes.Count == 0)
+            AnsiConsole.MarkupLine("[green]No redundant links found.[/]");
+        else
+        {
+            foreach (var change in changes)
+                AnsiConsole.MarkupLine($"[yellow]{change}[/]");
+        }
+
+        return 0;
+    }
+
+    private static void PrintReferenceTree(Dictionary<string, List<string>> graph, string proj, object parent, HashSet<string> visited)
+    {
+        visited.Add(proj);
+        foreach (var reference in graph[proj])
+        {
+            var nodeLabel = reference.EndsWith(".csproj") ? Path.GetFileName(reference) : reference;
+            TreeNode child;
+            switch (parent)
+            {
+                case Tree tree:
+                    child = tree.AddNode(nodeLabel);
+                    break;
+                case TreeNode node:
+                    child = node.AddNode(nodeLabel);
+                    break;
+                default:
+                    continue;
+            }
+            if (reference.EndsWith(".csproj") && !visited.Contains(reference) && graph.ContainsKey(reference))
+            {
+                PrintReferenceTree(graph, reference, child, visited);
+            }
+        }
+    }
+
+    private static string GenerateMermaidMarkdown(Dictionary<string, List<string>> graph, string title, string fileName)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine($"# {fileName}\n");
+        sb.AppendLine("````mermaid");
+        sb.AppendLine("---");
+        sb.AppendLine($"title: {title}");
+        sb.AppendLine("---");
+        sb.AppendLine("graph TD");
+        foreach (var kvp in graph)
+        {
+            var from = Path.GetFileNameWithoutExtension(kvp.Key);
+            foreach (var toProj in kvp.Value.Where(x => x.EndsWith(".csproj")))
+            {
+                var to = Path.GetFileNameWithoutExtension(toProj);
+                sb.AppendLine($"    {from} --> {to}");
+            }
+        }
+        sb.AppendLine("````");
+        return sb.ToString();
+    }
+}

--- a/Csproj/DomainServices/ProjectManipulator.cs
+++ b/Csproj/DomainServices/ProjectManipulator.cs
@@ -1,5 +1,7 @@
 ﻿using System.Xml.Linq;
 
+// ReSharper disable once InvertIf
+
 namespace Csproj.DomainServices;
 
 internal class ProjectManipulator
@@ -113,5 +115,134 @@ internal class ProjectManipulator
 
     public string GetXml()
         => _project.ToString();
+
+    public static Dictionary<string, List<string>> BuildDependencyGraph(IEnumerable<string> projectPaths)
+    {
+        var graph = new Dictionary<string, List<string>>();
+        foreach (var path in projectPaths)
+        {
+            var doc = XDocument.Load(path);
+            var refs = doc.Descendants("ProjectReference")
+                .Select(pr => pr.Attribute("Include")?.Value)
+                .Where(include => !string.IsNullOrEmpty(include))
+                .Select(include => Path.GetFullPath(Path.Combine(Path.GetDirectoryName(path)!, include!)))
+                .ToList();
+            
+            refs.AddRange(
+                doc
+                    .Descendants("PackageReference")
+                    .Select(nr => nr.Attribute("Include")?.Value)
+                    .Where(pkg => !string.IsNullOrEmpty(pkg))!);
+            
+            graph[path] = refs;
+        }
+        return graph;
+    }
+
+    public static List<string> PruneRedundantLinks(Dictionary<string, List<string>> graph, bool dryRun, bool backup)
+    {
+        var changes = new List<string>();
+        foreach (var proj in graph.Keys)
+        {
+            var directRefs = graph[proj].Where(r => r.EndsWith(".csproj")).ToList();
+            var directNuGets = graph[proj].Where(r => !r.EndsWith(".csproj")).ToList();
+
+            // Remove redundant project references
+            foreach (var refProj in directRefs
+                         .Where(refProj => IsReachable(graph, proj, refProj, [proj], skipDirect: true)))
+            {
+                changes.Add($"Redundant project reference: {proj} -> {refProj}");
+                if (!dryRun)
+                {
+                    RemoveProjectReference(proj, refProj, backup);
+                }
+            }
+
+            // Remove redundant NuGet references
+            foreach (var nuget in directNuGets
+                         .Where(nuget => directRefs.Any(refProj => IsNuGetReachable(graph, refProj, nuget, [proj]))))
+            {
+                changes.Add($"Redundant NuGet reference: {proj} -> {nuget}");
+                if (!dryRun)
+                {
+                    RemoveNuGetReference(proj, nuget, backup);
+                }
+            }
+        }
+        return changes;
+    }
+
+    private static bool IsReachable(Dictionary<string, List<string>> graph, string from, string target, HashSet<string> visited, bool skipDirect)
+    {
+        foreach (var next in graph[from])
+        {
+            if (next == target && !skipDirect) return true;
+            if (next == target && skipDirect) continue;
+            if (next.EndsWith(".csproj") && visited.Add(next))
+            {
+                if (IsReachable(graph, next, target, visited, false)) return true;
+            }
+        }
+        return false;
+    }
+
+    private static void RemoveProjectReference(string projPath, string refProjPath, bool backup)
+    {
+        var doc = XDocument.Load(projPath);
+        var refs = doc
+            .Descendants("ProjectReference")
+            .Where(pr => Path.GetFullPath(Path.Combine(Path.GetDirectoryName(projPath)!, pr.Attribute("Include")?.Value ?? "")) == refProjPath)
+            .ToList();
+        
+        foreach (var pr in refs)
+        {
+            pr.Remove();
+        }
+        
+        if (backup)
+        {
+            File.Copy(projPath, projPath + ".bak", overwrite:true);
+        }
+        
+        doc.Save(projPath);
+    }
+    
+    private static bool IsNuGetReachable(Dictionary<string, List<string>> graph, string from, string nuget, HashSet<string> visited)
+    {
+        if (!graph.TryGetValue(from, out List<string>? refs) || !visited.Add(from))
+        {
+            return false;
+        }
+        
+        return refs.Any(r => r == nuget)
+               || refs
+                   .Where(r => r.EndsWith(".csproj"))
+                   .Any(refProj => IsNuGetReachable(graph, refProj, nuget, visited));
+    }
+    
+    private static void RemoveNuGetReference(string projPath, string nuget, bool backup)
+    {
+        var doc = XDocument.Load(projPath);
+        var toRemove = doc.Descendants("PackageReference")
+            .Where(pr => pr.Attribute("Include")?.Value == nuget)
+            .ToList();
+
+        if (toRemove.Count == 0)
+        {
+            return;
+        }
+        
+        foreach (var node in toRemove)
+        {
+            node.Remove();
+        }
+        
+        if (backup)
+        {
+            File.Copy(projPath, projPath + ".bak", true);
+        }
+        
+        doc.Save(projPath);
+    }
 
 }

--- a/Csproj/DomainServices/SolutionFileParser.cs
+++ b/Csproj/DomainServices/SolutionFileParser.cs
@@ -49,4 +49,11 @@ internal static class SolutionFileParser
             }
         }
     }
+
+    public static IEnumerable<string> GetAllProjectPaths(string solutionPath)
+    {
+        using var reader = new StreamReader(solutionPath);
+        var folder = Path.GetDirectoryName(solutionPath) ?? "";
+        return GetProjects(reader, ".csproj", folder).ToList();
+    }
 }

--- a/Csproj/Program.cs
+++ b/Csproj/Program.cs
@@ -21,6 +21,9 @@ app.Configure(cfg =>
     cfg.AddCommand<Csproj.Commands.Version>("version")
         .WithDescription("Set project versions");
 
+    cfg.AddCommand<Csproj.Commands.PruneLinks>("prunelinks")
+       .WithDescription("Inspect and remove redundant project/NuGet references in solution projects");
+
     cfg.AddBranch("licenseheaders", headers =>
     {
         headers.AddCommand<Csproj.Commands.HeadersApply>("apply")

--- a/README.md
+++ b/README.md
@@ -61,3 +61,134 @@ OPTIONS:
     -n, --nullability    The nullability to upgrade to
 ```
 
+### version
+
+```
+DESCRIPTION:
+Set project, file, and assembly versions
+
+USAGE:
+    csproj version [OPTIONS]
+
+OPTIONS:
+    -h, --help             Prints help information
+    -p, --project          Project File Path. Can be a directory or a single project file. If not provided, the current directory is used
+    -r, --recursive        Recursive search for csproj files
+    -f, --filter           Filter project files by name. Wildcards like * and ? are supported
+    -b, --backup           Create a backup of the project file
+    -v, --version          The version prefix to set (e.g. 1.2.3.4)
+    -a, --assembly         The assembly version to set (e.g. 1.2.3.4)
+    -f, --file             The file version to set (e.g. 1.2.3.4)
+```
+
+Example: set all project versions in the current directory to 1.2.3.4:
+
+```bash
+csproj version --version 1.2.3.4
+```
+
+Example: set assembly and file versions for all projects recursively:
+
+```bash
+csproj version --recursive --assembly 1.2.3.4 --file 1.2.3.4
+```
+
+### licenseheaders
+
+#### apply
+
+```
+DESCRIPTION:
+Apply license headers to source files using a specified template
+
+USAGE:
+    csproj licenseheaders apply [OPTIONS]
+
+OPTIONS:
+    -h, --help             Prints help information
+    -d, --directory        Directory to process. Default: current working directory
+    -t, --template         License template file (default: licenses.xml in current directory)
+    -D, --dryrun           Dryrun mode. Don't do any changes, just output what would happen
+    -r, --recursive        Process subdirectories as well
+```
+
+Example: apply license headers recursively using a custom template:
+
+```bash
+csproj licenseheaders apply --directory src --template my_license.xml --recursive
+```
+
+#### create
+
+```
+DESCRIPTION:
+Create a default license headers template file (licenses.xml)
+
+USAGE:
+    csproj licenseheaders create
+```
+
+Example: create a default license header template in the current directory:
+
+```bash
+csproj licenseheaders create
+```
+
+### prunelinks
+
+```
+DESCRIPTION:
+Inspect and remove redundant project/NuGet references in solution projects. Optionally outputs a dependency graph in Markdown/Mermaid format.
+
+USAGE:
+    csproj prunelinks [OPTIONS] --solution <SolutionFile.sln>
+
+OPTIONS:
+    -h, --help           Prints help information
+    -s, --solution       Solution file path (.sln)
+    -D, --dryrun         Only show what would be changed, do not modify files
+    -b, --backup         Create a backup of the project file before editing
+    -v, --verbose        Show the reference tree for each project
+    --graph-md [file]    Output the dependency graph as a Markdown file with Mermaid syntax. If no file is specified, defaults to <SolutionName>.md in the solution directory.
+```
+
+#### Example: Remove redundant links and output dependency graph
+
+```bash
+csproj prunelinks --solution MySolution.sln --graph-md
+```
+This will create `MySolution.md` in the same directory as the solution, containing a Mermaid graph of project dependencies.
+
+#### Example: Specify a custom Markdown output file
+
+```bash
+csproj prunelinks --solution MySolution.sln --graph-md dependencies.md
+```
+
+#### Example Mermaid Markdown output
+
+```markdown
+# MySolution.md
+
+````mermaid
+---
+title: MySolution
+---
+graph TD
+    ProjectA --> ProjectB
+    ProjectB --> ProjectC
+    ProjectA --> ProjectC
+````
+
+That gives you a visual representation of the project dependencies in your solution. You can open this Markdown file in any compatible viewer that supports Mermaid diagrams to see the graph rendered visually.
+
+````mermaid
+---
+title: MySolution
+---
+graph TD
+    ProjectA --> ProjectB
+    ProjectB --> ProjectC
+    ProjectA --> ProjectC
+````
+


### PR DESCRIPTION
This pull request introduces a new `prunelinks` command to the project, allowing users to inspect and remove redundant project and NuGet references from solution projects. It also adds functionality to visualize project dependencies as a Markdown file with Mermaid syntax. The implementation includes updates to the CLI, supporting domain services, and documentation.

**New Command and CLI Integration**

* Added the `PruneLinks` command (`PruneLinks.cs`) with options for dry-run, backup, verbose output, and Markdown graph generation. This command analyzes solution files for redundant references and can output a visual dependency graph.
* Registered the new `prunelinks` command in the CLI configuration (`Program.cs`), making it available to users.

**Dependency Analysis and Pruning Logic**

* Implemented `BuildDependencyGraph` and `PruneRedundantLinks` methods in `ProjectManipulator.cs` to construct project reference graphs and identify/remove redundant project and NuGet references. Includes logic for backup and dry-run modes.
* Added helper methods for traversing project references and removing them from `.csproj` files, supporting both project and NuGet references.
* Provided a method in `SolutionFileParser.cs` to retrieve all project paths from a solution file, supporting the new command's operations.

**Documentation Updates**

* Updated `README.md` to describe the new `prunelinks` command, its options, usage examples, and Mermaid Markdown output for visualizing dependencies