### PR TITLE
Add prunelink solution and csproj support

### DIFF
--- a/Csproj/Commands/PruneLinks.cs
+++ b/Csproj/Commands/PruneLinks.cs
@@ -41,111 +41,192 @@ internal sealed class PruneLinks : Command<PruneLinks.Settings>
         public string GraphMdPath { get; set; } = string.Empty;
     }
 
+    /// <summary>
+    /// Executes the prune links command, validating input and performing project reference pruning.
+    /// </summary>
+    /// <param name="context">The command context.</param>
+    /// <param name="settings">The command settings. See <see cref="Settings"/>.</param>
+    /// <returns>Exit code: 0 for success, -1 for error.</returns>
     public override int Execute(CommandContext context, Settings settings)
     {
-        // Validate that exactly one of --solution or --csproj is provided
-        bool hasSolution = !string.IsNullOrWhiteSpace(settings.SolutionPath);
-        bool hasCsproj = !string.IsNullOrWhiteSpace(settings.CsprojPath);
-        if (hasSolution == hasCsproj)
+        var errorMessage = ValidateInput(settings);
+        if (errorMessage is not null)
         {
-            AnsiConsole.MarkupLine("[red]You must specify either --solution or --csproj, but not both.[/]");
+            AnsiConsole.MarkupLine($"[red]{errorMessage}[/]");
             return -1;
         }
 
-        List<string> projects;
-        string rootPath;
+        (List<string> projects, string rootPath) = GetProjectsAndRootPath(settings);
+        var allProjects = projects.ToHashSet();
+        var originalGraph = ProjectManipulator.BuildDependencyGraph(projects);
+        var changes = ProjectManipulator.PruneRedundantLinks(originalGraph, settings.DryRun, settings.Backup);
+        var displayGraph = SelectDisplayGraph(settings, projects, originalGraph);
+
+        if (settings.Verbose)
+        {
+            DisplayReferenceTrees(displayGraph, allProjects);
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.GraphMdPath))
+        {
+            OutputDependencyGraphMarkdown(settings, displayGraph, allProjects, rootPath);
+        }
+
+        ReportChanges(changes);
+        return 0;
+    }
+
+    /// <summary>
+    /// Selects the dependency graph to display based on dry run mode.
+    /// </summary>
+    /// <param name="settings">The command settings. See <see cref="Settings"/>.</param>
+    /// <param name="projects">List of project paths.</param>
+    /// <param name="originalGraph">The original dependency graph.</param>
+    /// <returns>The dependency graph to display.</returns>
+    private static Dictionary<string, List<string>> SelectDisplayGraph(
+        Settings settings,
+        List<string> projects,
+        Dictionary<string, List<string>> originalGraph)
+    {
+        return settings.DryRun ? originalGraph : ProjectManipulator.BuildDependencyGraph(projects);
+    }
+
+    /// <summary>
+    /// Reports the changes made to project references.
+    /// </summary>
+    /// <param name="changes">List of change descriptions.</param>
+    private static void ReportChanges(List<string> changes)
+    {
+        if (changes.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[green]No redundant links found.[/]");
+            return;
+        }
+
+        foreach (var change in changes)
+        {
+            AnsiConsole.MarkupLine($"[yellow]{change}[/]");
+        }
+    }
+
+    /// <summary>
+    /// Gets the list of projects and the root path from the provided settings.
+    /// </summary>
+    /// <param name="settings">The command settings. See <see cref="Settings"/>.</param>
+    /// <returns>Tuple containing the list of projects and the root path.</returns>
+    private static (List<string> projects, string rootPath) GetProjectsAndRootPath(Settings settings)
+    {
+        bool hasSolution = !string.IsNullOrWhiteSpace(settings.SolutionPath);
+        if (hasSolution)
+        {
+            var projects = SolutionFileParser.GetAllProjectPaths(settings.SolutionPath).ToList();
+            return (projects, settings.SolutionPath);
+        }
+        else
+        {
+            var projects = ProjectManipulator.CollectAllReferencedProjects(settings.CsprojPath);
+            return (projects, settings.CsprojPath);
+        }
+    }
+
+    /// <summary>
+    /// Validates the input settings for the command.
+    /// </summary>
+    /// <param name="settings">The command settings. See <see cref="Settings"/>.</param>
+    /// <returns>Error message if invalid, otherwise null.</returns>
+    private static string? ValidateInput(Settings settings)
+    {
+        bool hasSolution = !string.IsNullOrWhiteSpace(settings.SolutionPath);
+        bool hasCsproj = !string.IsNullOrWhiteSpace(settings.CsprojPath);
+        
+        if (hasSolution == hasCsproj)
+        {
+            return ("You must specify either --solution or --csproj, but not both.");
+        }
+        
         if (hasSolution)
         {
             if (!File.Exists(settings.SolutionPath))
             {
-                AnsiConsole.MarkupLine($"[red]Solution file not found: {settings.SolutionPath}[/]");
-                return -1;
+                return ($"Solution file not found: {settings.SolutionPath}");
             }
+                
             var ext = Path.GetExtension(settings.SolutionPath).ToLowerInvariant();
             if (ext != ".sln" && ext != ".slnx")
             {
-                AnsiConsole.MarkupLine($"[red]Unsupported solution file extension: {ext}. Only .sln and .slnx are supported.[/]");
-                return -1;
+                return ($"Unsupported solution file extension: {ext}. Only .sln and .slnx are supported.");
             }
-            projects = SolutionFileParser.GetAllProjectPaths(settings.SolutionPath).ToList();
-            rootPath = settings.SolutionPath;
         }
         else
         {
             if (!File.Exists(settings.CsprojPath))
-            {
-                AnsiConsole.MarkupLine($"[red]Project file not found: {settings.CsprojPath}[/]");
-                return -1;
-            }
-            // Recursively collect all referenced projects
-            projects = ProjectManipulator.CollectAllReferencedProjects(settings.CsprojPath);
-            rootPath = settings.CsprojPath;
+                return ($"Project file not found: {settings.CsprojPath}");
         }
+        return null;
+    }
 
-        var originalGraph = ProjectManipulator.BuildDependencyGraph(projects);
-        var allProjects = projects.ToHashSet();
-        var changes = ProjectManipulator.PruneRedundantLinks(originalGraph, settings.DryRun, settings.Backup);
-        var displayGraph = settings.DryRun ? originalGraph : ProjectManipulator.BuildDependencyGraph(projects);
-        if (!settings.DryRun)
+    /// <summary>
+    /// Displays the reference trees for each root project using <see cref="ProjectManipulator.PrintReferenceTree"/>.
+    /// </summary>
+    /// <param name="displayGraph">The dependency graph to display.</param>
+    /// <param name="allProjects">All project paths.</param>
+    private static void DisplayReferenceTrees(Dictionary<string, List<string>> displayGraph, HashSet<string> allProjects)
+    {
+        var displayReferencedProjects = new HashSet<string>();
+        foreach (var r in displayGraph.Values.SelectMany(refs => refs).Where(r => r.EndsWith(CsProj)))
         {
-            displayGraph = ProjectManipulator.BuildDependencyGraph(projects);
+            displayReferencedProjects.Add(r);
         }
-
-        if (settings.Verbose)
+        var displayRootProjects = allProjects.Except(displayReferencedProjects).ToList();
+        foreach (var proj in displayRootProjects)
         {
-            var displayReferencedProjects = new HashSet<string>();
-            foreach (var r in displayGraph.Values.SelectMany(refs => refs).Where(r => r.EndsWith(CsProj)))
-            {
-                displayReferencedProjects.Add(r);
-            }
-            var displayRootProjects = allProjects.Except(displayReferencedProjects).ToList();
-            foreach (var proj in displayRootProjects)
-            {
-                var tree = new Tree($"[bold]{Path.GetFileName(proj)}[/]");
-                ProjectManipulator.PrintReferenceTree(displayGraph, proj, tree, []);
-                AnsiConsole.Write(tree);
-            }
+            var tree = new Tree($"[bold]{Path.GetFileName(proj)}[/]");
+            ProjectManipulator.PrintReferenceTree(displayGraph, proj, tree, []);
+            AnsiConsole.Write(tree);
         }
+    }
 
-        // Determine output file path for --graph-md
-        if (!string.IsNullOrWhiteSpace(settings.GraphMdPath))
+    /// <summary>
+    /// Outputs the dependency graph as a Markdown file with Mermaid syntax using <see cref="GraphMarkdownUtil.GenerateMermaidMarkdown"/>.
+    /// </summary>
+    /// <param name="settings">The command settings. See <see cref="Settings"/>.</param>
+    /// <param name="displayGraph">The dependency graph to display.</param>
+    /// <param name="allProjects">All project paths.</param>
+    /// <param name="rootPath">The root solution or project path.</param>
+    private static void OutputDependencyGraphMarkdown(
+        Settings settings,
+        Dictionary<string, List<string>> displayGraph,
+        HashSet<string> allProjects,
+        string rootPath)
+    {
+        var solutionDir = Path.GetDirectoryName(rootPath);
+        var outputPath = Path.IsPathRooted(settings.GraphMdPath)
+            ? settings.GraphMdPath
+            : Path.Combine(solutionDir ?? string.Empty, settings.GraphMdPath);
+        var outputFileName = Path.GetFileName(outputPath);
+        var mdReferencedProjects = new HashSet<string>();
+        
+        foreach (var r in displayGraph.Values.SelectMany(refs => refs).Where(r => r.EndsWith(CsProj)))
         {
-            var solutionDir = Path.GetDirectoryName(rootPath);
-            var outputPath = Path.IsPathRooted(settings.GraphMdPath)
-                ? settings.GraphMdPath
-                : Path.Combine(solutionDir ?? string.Empty, settings.GraphMdPath);
-            var outputFileName = Path.GetFileName(outputPath);
-            // Use displayGraph for Markdown
-            var mdReferencedProjects = new HashSet<string>();
-            foreach (var r in displayGraph.Values.SelectMany(refs => refs).Where(r => r.EndsWith(CsProj)))
-            {
-                mdReferencedProjects.Add(r);
-            }
-            List<string> mdRootProjects;
-            string mdTitle;
-            if (hasCsproj)
-            {
-                mdRootProjects = [settings.CsprojPath];
-                mdTitle = Path.GetFileNameWithoutExtension(settings.CsprojPath);
-            }
-            else
-            {
-                mdRootProjects = allProjects.Except(mdReferencedProjects).ToList();
-                mdTitle = mdRootProjects.Count > 0 ? Path.GetFileNameWithoutExtension(mdRootProjects[0]) : "dependencies";
-            }
-            var mermaidMd = GraphMarkdownUtil.GenerateMermaidMarkdown(displayGraph, mdTitle, outputFileName, mdRootProjects);
-            File.WriteAllText(outputPath, mermaidMd);
-            AnsiConsole.MarkupLine($"[green]Dependency graph written to:[/] {outputPath}");
+            mdReferencedProjects.Add(r);
         }
-
-        if (changes.Count == 0)
-            AnsiConsole.MarkupLine("[green]No redundant links found.[/]");
+        
+        List<string> mdRootProjects;
+        string mdTitle;
+        bool hasCsproj = !string.IsNullOrWhiteSpace(settings.CsprojPath);
+        if (hasCsproj)
+        {
+            mdRootProjects = [settings.CsprojPath];
+            mdTitle = Path.GetFileNameWithoutExtension(settings.CsprojPath);
+        }
         else
         {
-            foreach (var change in changes)
-                AnsiConsole.MarkupLine($"[yellow]{change}[/]");
+            mdRootProjects = allProjects.Except(mdReferencedProjects).ToList();
+            mdTitle = mdRootProjects.Count > 0 ? Path.GetFileNameWithoutExtension(mdRootProjects[0]) : "dependencies";
         }
-
-        return 0;
+        
+        var mermaidMd = GraphMarkdownUtil.GenerateMermaidMarkdown(displayGraph, mdTitle, outputFileName, mdRootProjects);
+        File.WriteAllText(outputPath, mermaidMd);
+        AnsiConsole.MarkupLine($"[green]Dependency graph written to:[/] {outputPath}");
     }
 }

--- a/Csproj/Commands/PruneLinks.cs
+++ b/Csproj/Commands/PruneLinks.cs
@@ -16,7 +16,7 @@ internal sealed class PruneLinks : Command<PruneLinks.Settings>
     
     public class Settings : CommandSettings
     {
-        [Description("Solution file path (.sln)")]
+        [Description("Solution file path (.sln or .slnx)")]
         [CommandOption("-s|--solution")]
         public string SolutionPath { get; set; } = string.Empty;
 
@@ -59,6 +59,12 @@ internal sealed class PruneLinks : Command<PruneLinks.Settings>
             if (!File.Exists(settings.SolutionPath))
             {
                 AnsiConsole.MarkupLine($"[red]Solution file not found: {settings.SolutionPath}[/]");
+                return -1;
+            }
+            var ext = Path.GetExtension(settings.SolutionPath).ToLowerInvariant();
+            if (ext != ".sln" && ext != ".slnx")
+            {
+                AnsiConsole.MarkupLine($"[red]Unsupported solution file extension: {ext}. Only .sln and .slnx are supported.[/]");
                 return -1;
             }
             projects = SolutionFileParser.GetAllProjectPaths(settings.SolutionPath).ToList();

--- a/Csproj/Commands/PruneLinks.cs
+++ b/Csproj/Commands/PruneLinks.cs
@@ -1,4 +1,6 @@
 ﻿using System.ComponentModel;
+using System.Xml;
+
 using Spectre.Console.Cli;
 using Spectre.Console;
 using Csproj.DomainServices;
@@ -10,11 +12,17 @@ namespace Csproj.Commands;
 
 internal sealed class PruneLinks : Command<PruneLinks.Settings>
 {
+    private const string CsProj = ".csproj";
+    
     public class Settings : CommandSettings
     {
         [Description("Solution file path (.sln)")]
         [CommandOption("-s|--solution")]
         public string SolutionPath { get; set; } = string.Empty;
+
+        [Description("Project file path (.csproj)")]
+        [CommandOption("--csproj")]
+        public string CsprojPath { get; set; } = string.Empty;
 
         [Description("Dryrun mode. Only show what would be changed.")]
         [CommandOption("-D|--dryrun")]
@@ -35,32 +43,52 @@ internal sealed class PruneLinks : Command<PruneLinks.Settings>
 
     public override int Execute(CommandContext context, Settings settings)
     {
-        if (string.IsNullOrWhiteSpace(settings.SolutionPath) || !File.Exists(settings.SolutionPath))
+        // Validate that exactly one of --solution or --csproj is provided
+        bool hasSolution = !string.IsNullOrWhiteSpace(settings.SolutionPath);
+        bool hasCsproj = !string.IsNullOrWhiteSpace(settings.CsprojPath);
+        if (hasSolution == hasCsproj)
         {
-            AnsiConsole.MarkupLine($"[red]Solution file not found: {settings.SolutionPath}[/]");
+            AnsiConsole.MarkupLine("[red]You must specify either --solution or --csproj, but not both.[/]");
             return -1;
         }
 
-        var projects = SolutionFileParser.GetAllProjectPaths(settings.SolutionPath).ToList();
+        List<string> projects;
+        string rootPath;
+        if (hasSolution)
+        {
+            if (!File.Exists(settings.SolutionPath))
+            {
+                AnsiConsole.MarkupLine($"[red]Solution file not found: {settings.SolutionPath}[/]");
+                return -1;
+            }
+            projects = SolutionFileParser.GetAllProjectPaths(settings.SolutionPath).ToList();
+            rootPath = settings.SolutionPath;
+        }
+        else
+        {
+            if (!File.Exists(settings.CsprojPath))
+            {
+                AnsiConsole.MarkupLine($"[red]Project file not found: {settings.CsprojPath}[/]");
+                return -1;
+            }
+            // Recursively collect all referenced projects
+            projects = CollectAllReferencedProjects(settings.CsprojPath);
+            rootPath = settings.CsprojPath;
+        }
+
         var originalGraph = ProjectManipulator.BuildDependencyGraph(projects);
-
-        // Find root project(s) once
         var allProjects = projects.ToHashSet();
-
-        // Prune redundant links and get updated graph
         var changes = ProjectManipulator.PruneRedundantLinks(originalGraph, settings.DryRun, settings.Backup);
-        var displayGraph = settings.DryRun ? originalGraph : ProjectManipulator.BuildDependencyGraph(projects); // Rebuild after prune
-
+        var displayGraph = settings.DryRun ? originalGraph : ProjectManipulator.BuildDependencyGraph(projects);
         if (!settings.DryRun)
         {
-            // Rebuild graph after pruning
             displayGraph = ProjectManipulator.BuildDependencyGraph(projects);
         }
 
         if (settings.Verbose)
         {
             var displayReferencedProjects = new HashSet<string>();
-            foreach (var r in displayGraph.Values.SelectMany(refs => refs).Where(r => r.EndsWith(".csproj")))
+            foreach (var r in displayGraph.Values.SelectMany(refs => refs).Where(r => r.EndsWith(CsProj)))
             {
                 displayReferencedProjects.Add(r);
             }
@@ -74,32 +102,32 @@ internal sealed class PruneLinks : Command<PruneLinks.Settings>
         }
 
         // Determine output file path for --graph-md
-        string? outputPath;
-        var solutionDir = Path.GetDirectoryName(settings.SolutionPath);
         if (!string.IsNullOrWhiteSpace(settings.GraphMdPath))
         {
-            outputPath = Path.IsPathRooted(settings.GraphMdPath)
+            var solutionDir = Path.GetDirectoryName(rootPath);
+            var outputPath = Path.IsPathRooted(settings.GraphMdPath)
                 ? settings.GraphMdPath
                 : Path.Combine(solutionDir ?? string.Empty, settings.GraphMdPath);
-        }
-        else
-        {
-            var solutionName = Path.GetFileNameWithoutExtension(settings.SolutionPath);
-            outputPath = Path.Combine(solutionDir ?? string.Empty, solutionName + ".md");
-        }
-
-        if (!string.IsNullOrWhiteSpace(outputPath))
-        {
             var outputFileName = Path.GetFileName(outputPath);
             // Use displayGraph for Markdown
             var mdReferencedProjects = new HashSet<string>();
-            foreach (var r in displayGraph.Values.SelectMany(refs => refs).Where(r => r.EndsWith(".csproj")))
+            foreach (var r in displayGraph.Values.SelectMany(refs => refs).Where(r => r.EndsWith(CsProj)))
             {
                 mdReferencedProjects.Add(r);
             }
-            var mdRootProjects = allProjects.Except(mdReferencedProjects).ToList();
-            var mdTitle = mdRootProjects.Count > 0 ? Path.GetFileNameWithoutExtension(mdRootProjects[0]) : "dependencies";
-            var mermaidMd = GenerateMermaidMarkdown(displayGraph, mdTitle, outputFileName);
+            List<string> mdRootProjects;
+            string mdTitle;
+            if (hasCsproj)
+            {
+                mdRootProjects = [settings.CsprojPath];
+                mdTitle = Path.GetFileNameWithoutExtension(settings.CsprojPath);
+            }
+            else
+            {
+                mdRootProjects = allProjects.Except(mdReferencedProjects).ToList();
+                mdTitle = mdRootProjects.Count > 0 ? Path.GetFileNameWithoutExtension(mdRootProjects[0]) : "dependencies";
+            }
+            var mermaidMd = GenerateMermaidMarkdown(displayGraph, mdTitle, outputFileName, mdRootProjects);
             File.WriteAllText(outputPath, mermaidMd);
             AnsiConsole.MarkupLine($"[green]Dependency graph written to:[/] {outputPath}");
         }
@@ -140,7 +168,7 @@ internal sealed class PruneLinks : Command<PruneLinks.Settings>
         }
     }
 
-    private static string GenerateMermaidMarkdown(Dictionary<string, List<string>> graph, string title, string fileName)
+    private static string GenerateMermaidMarkdown(Dictionary<string, List<string>> graph, string title, string fileName, List<string> rootProjects)
     {
         var sb = new System.Text.StringBuilder();
         sb.AppendLine($"# {fileName}\n");
@@ -149,16 +177,72 @@ internal sealed class PruneLinks : Command<PruneLinks.Settings>
         sb.AppendLine($"title: {title}");
         sb.AppendLine("---");
         sb.AppendLine("graph TD");
-        foreach (var kvp in graph)
+        var visited = new HashSet<string>();
+        foreach (var root in rootProjects)
         {
-            var from = Path.GetFileNameWithoutExtension(kvp.Key);
-            foreach (var toProj in kvp.Value.Where(x => x.EndsWith(".csproj")))
-            {
-                var to = Path.GetFileNameWithoutExtension(toProj);
-                sb.AppendLine($"    {from} --> {to}");
-            }
+            WriteMermaidEdges(graph, root, sb, visited);
         }
         sb.AppendLine("````");
         return sb.ToString();
+    }
+
+    private static void WriteMermaidEdges(Dictionary<string, List<string>> graph, string proj, System.Text.StringBuilder sb, HashSet<string> visited)
+    {
+        if (!visited.Add(proj)) return;
+        var from = Path.GetFileNameWithoutExtension(proj);
+        if (!graph.TryGetValue(proj, out var refs)) return;
+        foreach (var toProj in refs.Where(x => x.EndsWith(CsProj)))
+        {
+            var to = Path.GetFileNameWithoutExtension(toProj);
+            sb.AppendLine($"    {from} --> {to}");
+            WriteMermaidEdges(graph, toProj, sb, visited);
+        }
+    }
+
+    private static List<string> CollectAllReferencedProjects(string rootCsproj)
+    {
+        var found = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var stack = new Stack<string>();
+        stack.Push(rootCsproj);
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            if (!found.Add(current)) continue;
+            foreach (var reference in GetProjectReferencesFromFile(current)
+                         .Where(reference => reference.EndsWith(CsProj, StringComparison.OrdinalIgnoreCase)
+                                             && !found.Contains(reference)
+                                             && File.Exists(reference)))
+            {
+                stack.Push(reference);
+            }
+        }
+        return found.ToList();
+    }
+
+    // Helper to parse .csproj and get all referenced .csproj files (absolute paths)
+    private static List<string> GetProjectReferencesFromFile(string csprojPath)
+    {
+        var references = new List<string>();
+        try
+        {
+            var doc = new XmlDocument();
+            doc.Load(csprojPath);
+            var nodes = doc.SelectNodes("//ProjectReference[@Include]");
+            if (nodes != null)
+            {
+                var baseDir = Path.GetDirectoryName(csprojPath) ?? string.Empty;
+                references.AddRange(
+                    nodes.OfType<XmlNode>()
+                        .Select(node => node.Attributes?["Include"]?.Value)
+                        .Where(include => !string.IsNullOrWhiteSpace(include))
+                        .Select(include => Path.GetFullPath(Path.Combine(baseDir, include!)))
+                );
+            }
+        }
+        catch
+        {
+            // Ignore parse errors, treat as no references
+        }
+        return references;
     }
 }

--- a/Csproj/Commands/PruneLinks.cs
+++ b/Csproj/Commands/PruneLinks.cs
@@ -1,9 +1,9 @@
 ﻿using System.ComponentModel;
-using System.Xml;
 
 using Spectre.Console.Cli;
 using Spectre.Console;
 using Csproj.DomainServices;
+using Csproj.Infrastructure;
 
 // ReSharper disable UnusedAutoPropertyAccessor.Global
 // ReSharper disable ClassNeverInstantiated.Global
@@ -72,7 +72,7 @@ internal sealed class PruneLinks : Command<PruneLinks.Settings>
                 return -1;
             }
             // Recursively collect all referenced projects
-            projects = CollectAllReferencedProjects(settings.CsprojPath);
+            projects = ProjectManipulator.CollectAllReferencedProjects(settings.CsprojPath);
             rootPath = settings.CsprojPath;
         }
 
@@ -96,7 +96,7 @@ internal sealed class PruneLinks : Command<PruneLinks.Settings>
             foreach (var proj in displayRootProjects)
             {
                 var tree = new Tree($"[bold]{Path.GetFileName(proj)}[/]");
-                PrintReferenceTree(displayGraph, proj, tree, []);
+                ProjectManipulator.PrintReferenceTree(displayGraph, proj, tree, []);
                 AnsiConsole.Write(tree);
             }
         }
@@ -127,7 +127,7 @@ internal sealed class PruneLinks : Command<PruneLinks.Settings>
                 mdRootProjects = allProjects.Except(mdReferencedProjects).ToList();
                 mdTitle = mdRootProjects.Count > 0 ? Path.GetFileNameWithoutExtension(mdRootProjects[0]) : "dependencies";
             }
-            var mermaidMd = GenerateMermaidMarkdown(displayGraph, mdTitle, outputFileName, mdRootProjects);
+            var mermaidMd = GraphMarkdownUtil.GenerateMermaidMarkdown(displayGraph, mdTitle, outputFileName, mdRootProjects);
             File.WriteAllText(outputPath, mermaidMd);
             AnsiConsole.MarkupLine($"[green]Dependency graph written to:[/] {outputPath}");
         }
@@ -141,108 +141,5 @@ internal sealed class PruneLinks : Command<PruneLinks.Settings>
         }
 
         return 0;
-    }
-
-    private static void PrintReferenceTree(Dictionary<string, List<string>> graph, string proj, object parent, HashSet<string> visited)
-    {
-        visited.Add(proj);
-        foreach (var reference in graph[proj])
-        {
-            var nodeLabel = reference.EndsWith(".csproj") ? Path.GetFileName(reference) : reference;
-            TreeNode child;
-            switch (parent)
-            {
-                case Tree tree:
-                    child = tree.AddNode(nodeLabel);
-                    break;
-                case TreeNode node:
-                    child = node.AddNode(nodeLabel);
-                    break;
-                default:
-                    continue;
-            }
-            if (reference.EndsWith(".csproj") && !visited.Contains(reference) && graph.ContainsKey(reference))
-            {
-                PrintReferenceTree(graph, reference, child, visited);
-            }
-        }
-    }
-
-    private static string GenerateMermaidMarkdown(Dictionary<string, List<string>> graph, string title, string fileName, List<string> rootProjects)
-    {
-        var sb = new System.Text.StringBuilder();
-        sb.AppendLine($"# {fileName}\n");
-        sb.AppendLine("````mermaid");
-        sb.AppendLine("---");
-        sb.AppendLine($"title: {title}");
-        sb.AppendLine("---");
-        sb.AppendLine("graph TD");
-        var visited = new HashSet<string>();
-        foreach (var root in rootProjects)
-        {
-            WriteMermaidEdges(graph, root, sb, visited);
-        }
-        sb.AppendLine("````");
-        return sb.ToString();
-    }
-
-    private static void WriteMermaidEdges(Dictionary<string, List<string>> graph, string proj, System.Text.StringBuilder sb, HashSet<string> visited)
-    {
-        if (!visited.Add(proj)) return;
-        var from = Path.GetFileNameWithoutExtension(proj);
-        if (!graph.TryGetValue(proj, out var refs)) return;
-        foreach (var toProj in refs.Where(x => x.EndsWith(CsProj)))
-        {
-            var to = Path.GetFileNameWithoutExtension(toProj);
-            sb.AppendLine($"    {from} --> {to}");
-            WriteMermaidEdges(graph, toProj, sb, visited);
-        }
-    }
-
-    private static List<string> CollectAllReferencedProjects(string rootCsproj)
-    {
-        var found = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var stack = new Stack<string>();
-        stack.Push(rootCsproj);
-        while (stack.Count > 0)
-        {
-            var current = stack.Pop();
-            if (!found.Add(current)) continue;
-            foreach (var reference in GetProjectReferencesFromFile(current)
-                         .Where(reference => reference.EndsWith(CsProj, StringComparison.OrdinalIgnoreCase)
-                                             && !found.Contains(reference)
-                                             && File.Exists(reference)))
-            {
-                stack.Push(reference);
-            }
-        }
-        return found.ToList();
-    }
-
-    // Helper to parse .csproj and get all referenced .csproj files (absolute paths)
-    private static List<string> GetProjectReferencesFromFile(string csprojPath)
-    {
-        var references = new List<string>();
-        try
-        {
-            var doc = new XmlDocument();
-            doc.Load(csprojPath);
-            var nodes = doc.SelectNodes("//ProjectReference[@Include]");
-            if (nodes != null)
-            {
-                var baseDir = Path.GetDirectoryName(csprojPath) ?? string.Empty;
-                references.AddRange(
-                    nodes.OfType<XmlNode>()
-                        .Select(node => node.Attributes?["Include"]?.Value)
-                        .Where(include => !string.IsNullOrWhiteSpace(include))
-                        .Select(include => Path.GetFullPath(Path.Combine(baseDir, include!)))
-                );
-            }
-        }
-        catch
-        {
-            // Ignore parse errors, treat as no references
-        }
-        return references;
     }
 }

--- a/Csproj/DomainServices/ProjectManipulator.cs
+++ b/Csproj/DomainServices/ProjectManipulator.cs
@@ -1,4 +1,7 @@
-﻿using System.Xml.Linq;
+﻿using System.Xml;
+using System.Xml.Linq;
+
+using Spectre.Console;
 
 // ReSharper disable once InvertIf
 
@@ -243,6 +246,101 @@ internal class ProjectManipulator
         }
         
         doc.Save(projPath);
+    }
+
+    /// <summary>
+    /// Collects all referenced projects starting from the specified root .csproj file.
+    /// </summary>
+    /// <param name="rootCsproj">The path to the root .csproj file.</param>
+    /// <returns>A <see cref="List{string}"/> containing all referenced project file paths.</returns>
+    /// <seealso cref="GetProjectReferencesFromFile(string)"/>
+    public static List<string> CollectAllReferencedProjects(string rootCsproj)
+    {
+        var found = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var stack = new Stack<string>();
+        stack.Push(rootCsproj);
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            if (!found.Add(current)) continue;
+            foreach (var reference in GetProjectReferencesFromFile(current)
+                         .Where(reference => reference.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)
+                                             && !found.Contains(reference)
+                                             && File.Exists(reference)))
+            {
+                stack.Push(reference);
+            }
+        }
+        return found.ToList();
+    }
+
+    /// <summary>
+    /// Retrieves the project references from a given .csproj file.
+    /// </summary>
+    /// <param name="csprojPath">The path to the .csproj file.</param>
+    /// <returns>A <see cref="List{string}"/> of project reference file paths.</returns>
+    /// <seealso cref="CollectAllReferencedProjects(string)"/>
+    private static List<string> GetProjectReferencesFromFile(string csprojPath)
+    {
+        var references = new List<string>();
+        try
+        {
+            var doc = new XmlDocument();
+            doc.Load(csprojPath);
+            var nodes = doc.SelectNodes("//ProjectReference[@Include]");
+            if (nodes != null)
+            {
+                var baseDir = Path.GetDirectoryName(csprojPath) ?? string.Empty;
+                references.AddRange(
+                    nodes.OfType<XmlNode>()
+                        .Select(node => node.Attributes?["Include"]?.Value)
+                        .Where(include => !string.IsNullOrWhiteSpace(include))
+                        .Select(include => Path.GetFullPath(Path.Combine(baseDir, include!)))
+                );
+            }
+        }
+        catch
+        {
+            // Ignore parse errors, treat as no references
+        }
+        return references;
+    }
+
+    /// <summary>
+    /// Prints the project reference tree starting from the specified project.
+    /// </summary>
+    /// <param name="graph">A <see cref="Dictionary{string, List{string}}"/> representing the project dependency graph.</param>
+    /// <param name="proj">The current project being processed.</param>
+    /// <param name="parent">The parent node in the tree structure.</param>
+    /// <param name="visited">A <see cref="HashSet{string}"/> of already visited projects to avoid infinite recursion.</param>
+    /// <seealso cref="CollectAllReferencedProjects(string)"/>
+    public static void PrintReferenceTree(
+        Dictionary<string, List<string>> graph,
+        string proj,
+        object parent,
+        HashSet<string> visited)
+    {
+        visited.Add(proj);
+        foreach (var reference in graph[proj])
+        {
+            var nodeLabel = reference.EndsWith(".csproj") ? Path.GetFileName(reference) : reference;
+            TreeNode child;
+            switch (parent)
+            {
+                case Tree tree:
+                    child = tree.AddNode(nodeLabel);
+                    break;
+                case TreeNode node:
+                    child = node.AddNode(nodeLabel);
+                    break;
+                default:
+                    continue;
+            }
+            if (reference.EndsWith(".csproj") && !visited.Contains(reference) && graph.ContainsKey(reference))
+            {
+                PrintReferenceTree(graph, reference, child, visited);
+            }
+        }
     }
 
 }

--- a/Csproj/DomainServices/SolutionFileParser.cs
+++ b/Csproj/DomainServices/SolutionFileParser.cs
@@ -1,28 +1,51 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Xml.Linq;
+﻿using System.Xml.Linq;
+
+// ReSharper disable InvertIf
 
 namespace Csproj.DomainServices;
+
 internal static class SolutionFileParser
 {
-    public static IEnumerable<string> GetProjects(TextReader solutionContents, string projectExtension, string solutionFolder)
+    /// <summary>
+    /// Parses a solution file and retrieves the paths of all projects with the specified extension.
+    /// </summary>
+    /// <param name="solutionContents">The contents of the solution file as a <see cref="TextReader"/>.</param>
+    /// <param name="projectExtension">The file extension of the projects to retrieve (e.g., ".csproj").</param>
+    /// <param name="solutionFolder">The folder containing the solution file.</param>
+    /// <returns>An enumerable of full paths to the projects with the specified extension.</returns>
+    public static IEnumerable<string> GetProjects(
+        TextReader solutionContents,
+        string projectExtension,
+        string solutionFolder)
     {
         string? firstLine = solutionContents.ReadLine();
 
-        return firstLine == null
-            ? Enumerable.Empty<string>()
-            : firstLine.StartsWith("<Solution>")
-                ? GetProjectsFromSlnx(solutionContents, projectExtension, solutionFolder)
-                : GetProjectsFromSln(solutionContents, projectExtension, solutionFolder);
+        if (firstLine is null)
+        {
+            return [];
+        }
+        
+        // Determines the solution type and calls the appropriate parser.
+        return firstLine.StartsWith("<Solution>")
+            ? GetProjectsFromSlnx(solutionContents, projectExtension, solutionFolder)
+            : GetProjectsFromSln(solutionContents, projectExtension, solutionFolder);
     }
 
-    private static IEnumerable<string> GetProjectsFromSlnx(TextReader textReader, string projectExtension, string solutionFolder)
+    /// <summary>
+    /// Parses a .slnx solution file and retrieves the paths of all projects with the specified extension.
+    /// </summary>
+    /// <param name="textReader">The contents of the .slnx file as a <see cref="TextReader"/>.</param>
+    /// <param name="projectExtension">The file extension of the projects to retrieve (e.g., ".csproj").</param>
+    /// <param name="solutionFolder">The folder containing the solution file.</param>
+    /// <returns>An enumerable of full paths to the projects with the specified extension.</returns>
+    private static IEnumerable<string> GetProjectsFromSlnx(
+        TextReader textReader,
+        string projectExtension,
+        string solutionFolder)
     {
         XDocument xml = XDocument.Parse($"<Solution>{textReader.ReadToEnd()}");
-        var projectElements = xml.Root?.Elements().Where(element => element.Name == "Project") ?? Enumerable.Empty<XElement>();
+        // Recursively find all <Project> elements
+        var projectElements = xml.Descendants("Project");
         foreach (var projectElement in projectElements)
         {
             string? path = projectElement.Attribute("Path")?.Value;
@@ -33,10 +56,19 @@ internal static class SolutionFileParser
         }
     }
 
-    private static IEnumerable<string> GetProjectsFromSln(TextReader solutionContents, string projectExtension, string solutionFolder)
+    /// <summary>
+    /// Parses a .sln solution file and retrieves the paths of all projects with the specified extension.
+    /// </summary>
+    /// <param name="solutionContents">The contents of the .sln file as a <see cref="TextReader"/>.</param>
+    /// <param name="projectExtension">The file extension of the projects to retrieve (e.g., ".csproj").</param>
+    /// <param name="solutionFolder">The folder containing the solution file.</param>
+    /// <returns>An enumerable of full paths to the projects with the specified extension.</returns>
+    private static IEnumerable<string> GetProjectsFromSln(
+        TextReader solutionContents,
+        string projectExtension,
+        string solutionFolder)
     {
-        string? line = null;
-        while ((line = solutionContents.ReadLine()) != null)
+        while (solutionContents.ReadLine() is { } line)
         {
             if (line.StartsWith("Project("))
             {
@@ -50,6 +82,11 @@ internal static class SolutionFileParser
         }
     }
 
+    /// <summary>
+    /// Retrieves the paths of all projects in a solution file.
+    /// </summary>
+    /// <param name="solutionPath">The full path to the solution file.</param>
+    /// <returns>An enumerable of full paths to the projects in the solution file.</returns>
     public static IEnumerable<string> GetAllProjectPaths(string solutionPath)
     {
         using var reader = new StreamReader(solutionPath);

--- a/Csproj/Infrastructure/GraphMarkdownUtil.cs
+++ b/Csproj/Infrastructure/GraphMarkdownUtil.cs
@@ -1,0 +1,63 @@
+﻿using System.Text;
+
+namespace Csproj.Infrastructure;
+
+public static class GraphMarkdownUtil
+{
+    /// <summary>
+/// Generates a Mermaid Markdown representation of a project dependency graph.
+/// </summary>
+/// <param name="graph">A <see cref="Dictionary{TKey,TValue}"/> representing the project dependency graph, where keys are project paths and values are lists of referenced project paths.</param>
+/// <param name="title">The title of the Mermaid graph.</param>
+/// <param name="fileName">The name of the file to be displayed as the Markdown header.</param>
+/// <param name="rootProjects">A <see cref="List{T}"/> of root projects to start the graph traversal from.</param>
+/// <returns>A <see cref="string"/> containing the Mermaid Markdown representation of the graph.</returns>
+/// <seealso cref="WriteMermaidEdges(Dictionary{string, List{string}}, string, StringBuilder, HashSet{string})"/>
+    public static string GenerateMermaidMarkdown(
+        Dictionary<string, List<string>> graph,
+        string title,
+        string fileName,
+        List<string> rootProjects)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"# {fileName}\n");
+        sb.AppendLine("````mermaid");
+        sb.AppendLine("---");
+        sb.AppendLine($"title: {title}");
+        sb.AppendLine("---");
+        sb.AppendLine("graph TD");
+        var visited = new HashSet<string>();
+        foreach (var root in rootProjects)
+        {
+            WriteMermaidEdges(graph, root, sb, visited);
+        }
+        sb.AppendLine("````");
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Recursively writes edges of the Mermaid graph for a given project and its dependencies.
+    /// </summary>
+    /// <param name="graph">A <see cref="Dictionary{TKey,TValue}"/> representing the project dependency graph.</param>
+    /// <param name="proj">The current project being processed.</param>
+    /// <param name="sb">The <see cref="StringBuilder"/> used to construct the Mermaid graph.</param>
+    /// <param name="visited">A <see cref="HashSet{T}"/> of already visited projects to avoid infinite recursion.</param>
+    /// <seealso cref="GenerateMermaidMarkdown(Dictionary{string, List{string}}, string, string, List{string})"/>
+    private static void WriteMermaidEdges(
+        Dictionary<string, List<string>> graph,
+        string proj,
+        StringBuilder sb,
+        HashSet<string> visited)
+    {
+        if (!visited.Add(proj)) return;
+        var from = Path.GetFileNameWithoutExtension(proj);
+        if (!graph.TryGetValue(proj, out var refs)) return;
+        foreach (var toProj in refs.Where(x => x.EndsWith(".csproj")))
+        {
+            var to = Path.GetFileNameWithoutExtension(toProj);
+            sb.AppendLine($"    {from} --> {to}");
+            WriteMermaidEdges(graph, toProj, sb, visited);
+        }
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -138,26 +138,37 @@ csproj licenseheaders create
 
 ```
 DESCRIPTION:
-Inspect and remove redundant project/NuGet references in solution projects. Optionally outputs a dependency graph in Markdown/Mermaid format.
+Inspect and remove redundant project/NuGet references in solution or project files. Optionally outputs a dependency graph in Markdown/Mermaid format.
 
 USAGE:
     csproj prunelinks [OPTIONS] --solution <SolutionFile.sln>
+    csproj prunelinks [OPTIONS] --csproj <ProjectFile.csproj>
 
 OPTIONS:
     -h, --help           Prints help information
-    -s, --solution       Solution file path (.sln)
+    -s, --solution       Solution file path (.sln or .slnx)
+    --csproj             Project file path (.csproj)
     -D, --dryrun         Only show what would be changed, do not modify files
     -b, --backup         Create a backup of the project file before editing
     -v, --verbose        Show the reference tree for each project
-    --graph-md [file]    Output the dependency graph as a Markdown file with Mermaid syntax. If no file is specified, defaults to <SolutionName>.md in the solution directory.
+    --graph-md [file]    Output the dependency graph as a Markdown file with Mermaid syntax. If no file is specified, defaults to <SolutionName>.md or <ProjectName>.md in the solution/project directory.
+
+Note: You must specify either --solution or --csproj, but not both.
 ```
 
-#### Example: Remove redundant links and output dependency graph
+#### Example: Remove redundant links and output dependency graph for a solution
 
 ```bash
 csproj prunelinks --solution MySolution.sln --graph-md
 ```
 This will create `MySolution.md` in the same directory as the solution, containing a Mermaid graph of project dependencies.
+
+#### Example: Remove redundant links and output dependency graph for a single project
+
+```bash
+csproj prunelinks --csproj MyProject.csproj --graph-md
+```
+This will create `MyProject.md` in the same directory as the project file, containing a Mermaid graph of its dependencies.
 
 #### Example: Specify a custom Markdown output file
 
@@ -165,12 +176,29 @@ This will create `MySolution.md` in the same directory as the solution, containi
 csproj prunelinks --solution MySolution.sln --graph-md dependencies.md
 ```
 
+#### Example: Show reference trees for each root project
+
+```bash
+csproj prunelinks --solution MySolution.sln --verbose
+```
+
+#### Example: Dry run mode (show what would be changed, do not modify files)
+
+```bash
+csproj prunelinks --solution MySolution.sln --dryrun
+```
+
+#### Output
+- If no redundant links are found: `No redundant links found.`
+- If changes are detected, each change is listed in yellow.
+- If --graph-md is specified, a Markdown file with a Mermaid diagram is generated.
+
 #### Example Mermaid Markdown output
 
 ```markdown
 # MySolution.md
 
-````mermaid
+```mermaid
 ---
 title: MySolution
 ---


### PR DESCRIPTION
This pull request adds support for pruning redundant project references starting from either a solution file (`.sln`/`.slnx`) or a single `.csproj` file, improves input validation, and refactors the code for better modularity and maintainability. It also introduces more robust dependency graph reporting, including Markdown output with Mermaid diagrams.

**Support for both solution and project file inputs:**

* The `PruneLinks` command now accepts either a solution file (`--solution`) or a project file (`--csproj`) as input, with validation to ensure only one is specified at a time. This allows pruning references for standalone projects as well as solutions. [[1]](diffhunk://#diff-2ae6083cb3405a477db6fb56300629d80dd650537846202341344431a21f58bcR15-R26) [[2]](diffhunk://#diff-2ae6083cb3405a477db6fb56300629d80dd650537846202341344431a21f58bcR44-R230)

**Dependency graph and reporting improvements:**

* Added Markdown output for the dependency graph using Mermaid syntax, with correct handling for both solution and project roots. The output file location can be specified, and the graph is generated using the new `GraphMarkdownUtil.GenerateMermaidMarkdown` utility.
* Enhanced verbose mode to display reference trees for each root project, using a refactored `PrintReferenceTree` method. [[1]](diffhunk://#diff-2ae6083cb3405a477db6fb56300629d80dd650537846202341344431a21f58bcR44-R230) [[2]](diffhunk://#diff-2e4ca9e751e09b336b196cc63168a3fe6e92f229ac95e20225b27407bedd41b3R251-R345)

**Refactoring and modularization:**

* Moved project reference tree printing logic and project collection logic into new methods in `ProjectManipulator`, including `CollectAllReferencedProjects` and `PrintReferenceTree`, improving code reuse and readability.
* Improved solution file parsing in `SolutionFileParser` to support both `.sln` and `.slnx` formats, with documentation and more robust project element discovery. [[1]](diffhunk://#diff-695742ee5f5a70a3b8856eaa66b9334d912d1646cc4b867f94c7804907ec1726L1-R48) [[2]](diffhunk://#diff-695742ee5f5a70a3b8856eaa66b9334d912d1646cc4b867f94c7804907ec1726L36-R71) [[3]](diffhunk://#diff-695742ee5f5a70a3b8856eaa66b9334d912d1646cc4b867f94c7804907ec1726R85-R89)